### PR TITLE
fixed looking for cheapest hours 

### DIFF
--- a/wattwise.py
+++ b/wattwise.py
@@ -401,6 +401,7 @@ class WattWise(hass.Hass):
             history_data (list): List of historical consumption data.
         """
         try:
+
             def make_json_serializable(obj):
                 if isinstance(obj, dict):
                     return {k: make_json_serializable(v) for k, v in obj.items()}
@@ -409,9 +410,10 @@ class WattWise(hass.Hass):
                 elif isinstance(obj, datetime.datetime):
                     return obj.isoformat()
                 else:
-                     return obj
+                    return obj
+
             cleaned_data = make_json_serializable(history_data)
-            
+
             with open(self.CONSUMPTION_HISTORY_FILE, "w") as f:
                 json.dump(cleaned_data, f)
                 filepath = os.path.abspath(self.CONSUMPTION_HISTORY_FILE)
@@ -810,9 +812,56 @@ class WattWise(hass.Hass):
         cheapest_dates_8 = []
 
         # Check if window assignments are already set for the current forecast date
-        if (cheap_windows_data.get("forecast_date") != forecast_date.isoformat()) and (
-            now.hour > 13
-        ):
+        if now.hour == 15:
+            # New forecast period, find and save new windows
+            cheapest_hours_1 = self.find_cheapest_windows(self.price_forecast, 1)
+            cheapest_hours_2 = self.find_cheapest_windows(self.price_forecast, 2)
+            cheapest_hours_3 = self.find_cheapest_windows(self.price_forecast, 3)
+            cheapest_hours_4 = self.find_cheapest_windows(self.price_forecast, 4)
+            cheapest_hours_5 = self.find_cheapest_windows(self.price_forecast, 5)
+            cheapest_hours_6 = self.find_cheapest_windows(self.price_forecast, 6)
+            cheapest_hours_7 = self.find_cheapest_windows(self.price_forecast, 7)
+            cheapest_hours_8 = self.find_cheapest_windows(self.price_forecast, 8)
+
+            cheapest_dates_1 = [
+                relativeHourToDate(hour).isoformat() for hour in cheapest_hours_1
+            ]
+            cheapest_dates_2 = [
+                relativeHourToDate(hour).isoformat() for hour in cheapest_hours_2
+            ]
+            cheapest_dates_3 = [
+                relativeHourToDate(hour).isoformat() for hour in cheapest_hours_3
+            ]
+            cheapest_dates_4 = [
+                relativeHourToDate(hour).isoformat() for hour in cheapest_hours_4
+            ]
+            cheapest_dates_5 = [
+                relativeHourToDate(hour).isoformat() for hour in cheapest_hours_5
+            ]
+            cheapest_dates_6 = [
+                relativeHourToDate(hour).isoformat() for hour in cheapest_hours_6
+            ]
+            cheapest_dates_7 = [
+                relativeHourToDate(hour).isoformat() for hour in cheapest_hours_7
+            ]
+            cheapest_dates_8 = [
+                relativeHourToDate(hour).isoformat() for hour in cheapest_hours_8
+            ]
+
+            # Save windows
+            windows = {
+                "cheapest_dates_1": cheapest_dates_1,
+                "cheapest_dates_2": cheapest_dates_2,
+                "cheapest_dates_3": cheapest_dates_3,
+                "cheapest_dates_4": cheapest_dates_4,
+                "cheapest_dates_5": cheapest_dates_5,
+                "cheapest_dates_6": cheapest_dates_6,
+                "cheapest_dates_7": cheapest_dates_7,
+                "cheapest_dates_8": cheapest_dates_8,
+            }
+             self.save_cheap_windows(forecast_date, windows)
+            self.log(f"New cheap windows found for {forecast_date}: {windows}")
+        elif now.hour == 0:
             # New forecast period, find and save new windows
             cheapest_hours_1 = self.find_cheapest_windows(self.price_forecast, 1)
             cheapest_hours_2 = self.find_cheapest_windows(self.price_forecast, 2)
@@ -982,9 +1031,72 @@ class WattWise(hass.Hass):
         most_expensive_dates_8 = []
 
         # Check if window assignments are already set for the current forecast date
-        if (
-            expensive_windows_data.get("forecast_date") != forecast_date.isoformat()
-        ) and (now.hour > 13):
+        if now.hour == 15:
+            # New forecast period, find and save new windows
+            most_expensive_hours_1 = self.find_most_expensive_windows(
+                self.price_forecast, 1
+            )
+            most_expensive_hours_2 = self.find_most_expensive_windows(
+                self.price_forecast, 2
+            )
+            most_expensive_hours_3 = self.find_most_expensive_windows(
+                self.price_forecast, 3
+            )
+            most_expensive_hours_4 = self.find_most_expensive_windows(
+                self.price_forecast, 4
+            )
+            most_expensive_hours_5 = self.find_most_expensive_windows(
+                self.price_forecast, 5
+            )
+            most_expensive_hours_6 = self.find_most_expensive_windows(
+                self.price_forecast, 6
+            )
+            most_expensive_hours_7 = self.find_most_expensive_windows(
+                self.price_forecast, 7
+            )
+            most_expensive_hours_8 = self.find_most_expensive_windows(
+                self.price_forecast, 8
+            )
+
+            most_expensive_dates_1 = [
+                relativeHourToDate(hour).isoformat() for hour in most_expensive_hours_1
+            ]
+            most_expensive_dates_2 = [
+                relativeHourToDate(hour).isoformat() for hour in most_expensive_hours_2
+            ]
+            most_expensive_dates_3 = [
+                relativeHourToDate(hour).isoformat() for hour in most_expensive_hours_3
+            ]
+            most_expensive_dates_4 = [
+                relativeHourToDate(hour).isoformat() for hour in most_expensive_hours_4
+            ]
+            most_expensive_dates_5 = [
+                relativeHourToDate(hour).isoformat() for hour in most_expensive_hours_5
+            ]
+            most_expensive_dates_6 = [
+                relativeHourToDate(hour).isoformat() for hour in most_expensive_hours_6
+            ]
+            most_expensive_dates_7 = [
+                relativeHourToDate(hour).isoformat() for hour in most_expensive_hours_7
+            ]
+            most_expensive_dates_8 = [
+                relativeHourToDate(hour).isoformat() for hour in most_expensive_hours_8
+            ]
+
+            # Save windows
+            windows = {
+                "most_expensive_dates_1": most_expensive_dates_1,
+                "most_expensive_dates_2": most_expensive_dates_2,
+                "most_expensive_dates_3": most_expensive_dates_3,
+                "most_expensive_dates_4": most_expensive_dates_4,
+                "most_expensive_dates_5": most_expensive_dates_5,
+                "most_expensive_dates_6": most_expensive_dates_6,
+                "most_expensive_dates_7": most_expensive_dates_7,
+                 "most_expensive_dates_8": most_expensive_dates_8,
+            }
+            self.save_expensive_windows(forecast_date, windows)
+            self.log(f"New expensive windows found for {forecast_date}: {windows}")
+        elif now.hour == 0:
             # New forecast period, find and save new windows
             most_expensive_hours_1 = self.find_most_expensive_windows(
                 self.price_forecast, 1

--- a/wattwise.yaml
+++ b/wattwise.yaml
@@ -25,27 +25,68 @@ automation:
         data: {}
     mode: single
 
-sensor:
-  - platform: rest
-    unique_id: wattwise_tibber_prices
-    name: Wattwise Tibber Prices
-    resource: https://api.tibber.com/v1-beta/gql
-    method: POST
-    payload: '{ "query": "{ viewer { homes { currentSubscription { status priceInfo { current { total level } today { total level } tomorrow { total level } } } } } }" }'
-    json_attributes_path: "$.data.viewer.homes[0].currentSubscription.priceInfo"
-    json_attributes:
-      - today
-      - tomorrow
-    value_template: "{{ value_json.data.viewer.homes[0].currentSubscription.priceInfo.current.total | float }}"
-    scan_interval: 30
-    headers:
-      Authorization: !secret tibber_token
-      Content-Type: application/json
-      User-Agent: REST
-    unit_of_measurement: EUR/kWh
-
 template:
   - sensor:
+      - name: "Wattwise Tibber Prices"
+        unique_id: "wattwise_tibber_prices"
+        state: >
+          {% set ns = namespace(price='unknown') %}
+          {% set prices = state_attr('sensor.average_electricity_price', 'prices_today') %}
+          {% set idx = ((now().hour) % 24) %}
+          {% if prices and prices[idx] is defined %}
+            {% set ns.price = prices[idx].price | float | round(4) %}
+          {% endif %}
+          {{ ns.price }}
+        attributes:
+          today: >
+            {% set avg = states('sensor.average_electricity_price') | float(0) %}
+            {% set prices = state_attr('sensor.average_electricity_price', 'prices_today') %}
+            {% set ns = namespace(result=[]) %}
+            {% for item in prices %}
+              {% set price = item.get('price') %}
+              {% if price is not none and avg > 0 %}
+                {% set pct = (price / avg * 100) | float(0) %}
+                {% if pct < 60 %}
+                  {% set level = 'VERY_CHEAP' %}
+                {% elif pct <= 90 %}
+                  {% set level = 'CHEAP' %}
+                {% elif pct < 115 %}
+                  {% set level = 'NORMAL' %}
+                {% elif pct < 140 %}
+                  {% set level = 'EXPENSIVE' %}
+                {% else %}
+                  {% set level = 'VERY_EXPENSIVE' %}
+                {% endif %}
+                {% set entry = {'total': price | round(4), 'level': level} %}
+                {% set ns.result = ns.result + [entry] %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.result }}
+          tomorrow: >
+            {% set avg = states('sensor.average_electricity_price') | float(0) %}
+            {% set prices = state_attr('sensor.average_electricity_price', 'prices_tomorrow') %}
+            {% set ns = namespace(result=[]) %}
+            {% for item in prices %}
+              {% set price = item.get('price') %}
+              {% if price is not none and avg > 0 %}
+                {% set pct = (price / avg * 100) | float(0) %}
+                {% if pct < 60 %}
+                  {% set level = 'VERY_CHEAP' %}
+                {% elif pct <= 90 %}
+                  {% set level = 'CHEAP' %}
+                {% elif pct < 115 %}
+                  {% set level = 'NORMAL' %}
+                {% elif pct < 140 %}
+                  {% set level = 'EXPENSIVE' %}
+                {% else %}
+                  {% set level = 'VERY_EXPENSIVE' %}
+                {% endif %}
+                {% set entry = {'total': price | round(4), 'level': level} %}
+                {% set ns.result = ns.result + [entry] %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.result }}
+          unit_of_measurement: "EUR/kWh"
       - name: "WattWise Battery Charge from Solar"
         unique_id: "wattwise_battery_charge_from_solar"
         unit_of_measurement: "kW"
@@ -109,7 +150,7 @@ template:
         state: "{{ 0 }}"
         attributes:
           forecast: "{{ [] }}"
-      - name: "WattWise State of Charge (%)"
+      - name: "WattWise State of Charge Percentage"
         unique_id: "wattwise_state_of_charge_percentage"
         unit_of_measurement: "%"
         state_class: "measurement"


### PR DESCRIPTION
Problem:
The check for cheapest / expensive hours is only done for the day the forecast is published at 2 p.m. for the same day as it compares now.date and forecast.date. When there are cheap hours e.g. 2-4 p.m. this very day but even cheaper hours from e.g. 11-14h the next day, the script will only pull the cheap hours from 2-4 p.m. but ignore the cheap hours from tomorrow, even if the price is lower the next day.

Solution:
When the date changes at 0:00 the script will redo the check for cheapest hours on the new day.

changes have been made for expensive hours respectively.


P.s. it's the same as 2 weeks ago, I deleted that unintentionally. linitng should be fixed now